### PR TITLE
Use lt-time-fmt in lt-my-update

### DIFF
--- a/log-tools.el
+++ b/log-tools.el
@@ -394,7 +394,7 @@ length is larger than this value it won't be propertized."
     (lt-measure-region (region-beginning) (region-end))))
 
 (defun lt-my-update ()
-  (lt-update-overlay "%k:%M:%S.%6N"))
+  (lt-update-overlay lt-time-fmt))
 
 (defun lt-buffer-replace-command (msg)
   (delete-region (marker-position lt-input-marker) (point-max))


### PR DESCRIPTION
In that way, lt-time-fmt will be used instead of the current hardcoded
value when window configuration has been changed.